### PR TITLE
Fix quoting bug causing workflow crash

### DIFF
--- a/main.py
+++ b/main.py
@@ -83,10 +83,10 @@ if __name__ == '__main__':
                 for n in news:
                     # Prepare the task into a todoist Format
                     task_content = {
-                        'content': f'{n['title']}',
+                        'content': n["title"],
                         'project_id': project_id,
                         'labels': [entity[name_key]],
-                        'description': f"{n['url']}"
+                        'description': n["url"]
                     }
 
                     # Add task in Todoist


### PR DESCRIPTION
## Summary
- fix quoting in task payload building

## Testing
- `python main.py` *(fails: No module named 'feedparser')*

------
https://chatgpt.com/codex/tasks/task_e_6855dbc8b0748328b8577acd46fdc15f