### PR TITLE
Fix KeyError with missing feed dates

### DIFF
--- a/src/feeds/applemusic.py
+++ b/src/feeds/applemusic.py
@@ -10,9 +10,23 @@ class AppleMusicFeed:
         self.rss_feed = parse(self.channel_url)
 
     def _transform_feed(self, video):
-        dt_upload = datetime.fromisoformat(video['published'])
+        """Transform a raw feed entry to a simplified structure.
+
+        Some entries might not contain a ``published`` field. In that case the
+        entry is ignored to avoid ``KeyError`` exceptions.
+        """
+
+        published = video.get('published') or video.get('updated')
+        if not published:
+            return None
+
+        dt_upload = datetime.fromisoformat(published)
         if dt_upload > self.last_run:
-            return {"title" : video["title"],"url" : video["link"],"date_published" : video['published']}
+            return {
+                "title": video.get("title"),
+                "url": video.get("link"),
+                "date_published": published,
+            }
         
     def parse_feed(self):
         all_videos = list()

--- a/src/todoist.py
+++ b/src/todoist.py
@@ -65,7 +65,7 @@ class TaskManager:
     def add_task(self, content):
         exists = self._task_already_exists(content['content'], content['project_id'])
         if not exists:
-            print(f'Added : {content['content']}')
+            print(f"Added : {content['content']}")
             return self.api.make_request(method='post', endpoint='tasks', data=content)
         else:
             print('Already loaded')


### PR DESCRIPTION
## Summary
- handle missing `published` field in Apple Music feed entries
- fix f-string quoting in todoist task output

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6855dd0566888328a0613591d50f5cc6